### PR TITLE
Add .gitattributes to normalize line endings (CRLF for C# and XAML)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Set default behavior to handle line endings automatically
+* text=auto
+
+# C# and XAML files should use CRLF line endings
+*.cs text eol=crlf
+*.xaml text eol=crlf
+
+# Project files and configuration
+*.csproj text eol=crlf
+*.sln text eol=crlf
+*.slnx text eol=crlf
+*.props text eol=crlf
+*.targets text eol=crlf
+*.config text eol=crlf
+*.xml text eol=crlf
+*.manifest text eol=crlf
+
+# Documentation and text files
+*.md text eol=crlf
+*.txt text eol=crlf
+*.json text eol=crlf
+*.editorconfig text eol=crlf
+*.gitignore text eol=crlf
+*.gitattributes text eol=crlf
+
+# PowerShell scripts
+*.ps1 text eol=crlf
+
+# Binary files (prevent git from trying to modify line endings)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary


### PR DESCRIPTION
  ### 📝 PR Description
  
    ### Description
    This PR introduces a `.gitattributes` file to enforce consistent line endings (`CRLF`)   
  across C# (`.cs`), WinUI XAML (`.xaml`), and related configuration/project files.          
  
    ### Why this is needed
    Without a `.gitattributes` configuration, developers checking out or pulling the         
  repository on non-Windows platforms (like Linux or macOS) or with custom local Git settings
  will see dozens of files incorrectly flagged as modified due to line-ending mismatches (LF 
  vs CRLF). This fixes the issue and prevents false diffs.
  
    ### What this does
    - Sets the default text handling to automatic normalization (`* text=auto`).             
    - Explicitly mandates `CRLF` for C# source files (`*.cs`), WinUI files (`*.xaml`), and   
  Visual Studio project configurations (`*.csproj`, `*.sln`, `*.props`).
    - Marks image/icon assets as `binary` to prevent any accidental corruption.