### PR TITLE
Fix startup AccessViolation crash on XHCI IMOD memory reads

### DIFF
--- a/src/AutoOS.Core/Helpers/Device/DeviceHelper.cs
+++ b/src/AutoOS.Core/Helpers/Device/DeviceHelper.cs
@@ -537,14 +537,13 @@ public static partial class DeviceHelper
 				while (true)
 				{
 					CONFIGRET result = PInvoke.CM_Get_Next_Res_Des(out nuint nextResDes, currentHandle, 0, out CM_RESTYPE outResType, 0);
-					resType = (uint)outResType;
+					if (result != CONFIGRET.CR_SUCCESS)
+						break;
 
 					if (!isFirst && resDes != 0)
 						PInvoke.CM_Free_Res_Des_Handle(resDes);
 
-					if (result != CONFIGRET.CR_SUCCESS)
-						break;
-
+					resType = (uint)outResType;
 					resDes = nextResDes;
 					isFirst = false;
 					currentHandle = resDes;

--- a/src/AutoOS.Core/Helpers/Device/DeviceHelper.cs
+++ b/src/AutoOS.Core/Helpers/Device/DeviceHelper.cs
@@ -549,7 +549,7 @@ public static partial class DeviceHelper
 					isFirst = false;
 					currentHandle = resDes;
 
-					if (resType == 1 || resType == 7)
+					if (resType == (uint)CM_RESTYPE.ResType_Mem || resType == (uint)CM_RESTYPE.ResType_MemLarge)
 					{
 						uint dataSize;
 						if (PInvoke.CM_Get_Res_Des_Data_Size(&dataSize, resDes, 0) == CONFIGRET.CR_SUCCESS && dataSize >= 24)

--- a/src/AutoOS.Core/Helpers/ReadWrite/ReadWriteHelper.cs
+++ b/src/AutoOS.Core/Helpers/ReadWrite/ReadWriteHelper.cs
@@ -143,9 +143,6 @@ public partial class ReadWriteHelper : IDisposable
 
 		try
 		{
-			// IsBadReadPtr probes the range with SEH internally, so a faulting
-			// mapped physical address returns failure instead of raising an
-			// access violation that can crash the process during dispatch.
 			if (PInvoke.IsBadReadPtr((void*)(pLinAddr + (nint)extra), (nuint)length))
 				return false;
 
@@ -173,9 +170,6 @@ public partial class ReadWriteHelper : IDisposable
 
 		try
 		{
-			// IsBadWritePtr probes the range with SEH internally, so a faulting
-			// mapped physical address returns failure instead of raising an
-			// access violation that can crash the process during dispatch.
 			if (PInvoke.IsBadWritePtr((void*)(pLinAddr + (nint)extra), (nuint)buffer.Length))
 				return false;
 

--- a/src/AutoOS.Core/Helpers/ReadWrite/ReadWriteHelper.cs
+++ b/src/AutoOS.Core/Helpers/ReadWrite/ReadWriteHelper.cs
@@ -1,5 +1,5 @@
+using System.Runtime.InteropServices;
 using Windows.Win32;
-using Windows.Win32.System.Memory;
 
 namespace AutoOS.Core.Helpers.ReadWrite;
 
@@ -141,18 +141,15 @@ public partial class ReadWriteHelper : IDisposable
 		if (pLinAddr == IntPtr.Zero)
 			return false;
 
-		if (!IsReadableMemory(pLinAddr, (int)(extra + length)))
-		{
-			_ = InpOut.UnmapPhysicalMemory(hMapping, pLinAddr);
-			return false;
-		}
-
 		try
 		{
-			fixed (byte* pOutput = output)
-			{
-				Buffer.MemoryCopy((void*)(pLinAddr + (nint)extra), pOutput, length, length);
-			}
+			// IsBadReadPtr probes the range with SEH internally, so a faulting
+			// mapped physical address returns failure instead of raising an
+			// access violation that can crash the process during dispatch.
+			if (PInvoke.IsBadReadPtr((void*)(pLinAddr + (nint)extra), (nuint)length))
+				return false;
+
+			Marshal.Copy(pLinAddr + (nint)extra, output, 0, (int)length);
 			return true;
 		}
 		catch
@@ -165,49 +162,24 @@ public partial class ReadWriteHelper : IDisposable
 		}
 	}
 
-	private static unsafe bool IsReadableMemory(IntPtr address, int length)
-	{
-		ulong addr = (ulong)address.ToInt64();
-		long remaining = length;
-
-		while (remaining > 0)
-		{
-			MEMORY_BASIC_INFORMATION mbi;
-			if (PInvoke.VirtualQuery((void*)addr, &mbi, (nuint)sizeof(MEMORY_BASIC_INFORMATION)) == 0)
-				return false;
-
-			if (mbi.State != VIRTUAL_ALLOCATION_TYPE.MEM_COMMIT)
-				return false;
-
-			if ((mbi.Protect & (PAGE_PROTECTION_FLAGS.PAGE_GUARD | PAGE_PROTECTION_FLAGS.PAGE_NOACCESS)) != 0)
-				return false;
-
-			if ((mbi.Protect & (PAGE_PROTECTION_FLAGS.PAGE_READONLY | PAGE_PROTECTION_FLAGS.PAGE_READWRITE | PAGE_PROTECTION_FLAGS.PAGE_WRITECOPY | PAGE_PROTECTION_FLAGS.PAGE_EXECUTE_READ | PAGE_PROTECTION_FLAGS.PAGE_EXECUTE_READWRITE | PAGE_PROTECTION_FLAGS.PAGE_EXECUTE_WRITECOPY)) == 0)
-				return false;
-
-			ulong regionSize = (ulong)mbi.RegionSize;
-			if (regionSize == 0)
-				return false;
-
-			ulong regionEnd = (ulong)mbi.BaseAddress + regionSize;
-			remaining -= (long)Math.Min((ulong)remaining, regionEnd - addr);
-			addr = regionEnd;
-		}
-
-		return true;
-	}
-
 	public unsafe bool WriteMemory(ulong address, byte[] buffer)
 	{
-		IntPtr pLinAddr = InpOut.MapPhysToLin((IntPtr)address, (uint)buffer.Length, out nint hMapping);
+		ulong baseAddress = address & ~0xFFFUL;
+		uint extra = (uint)(address - baseAddress);
+		uint mapLength = extra + (uint)buffer.Length + 0x1000;
+
+		IntPtr pLinAddr = InpOut.MapPhysToLin((IntPtr)baseAddress, mapLength, out nint hMapping);
 		if (pLinAddr == IntPtr.Zero) return false;
 
 		try
 		{
-			fixed (byte* pBuffer = buffer)
-			{
-				Buffer.MemoryCopy(pBuffer, (void*)pLinAddr, buffer.Length, buffer.Length);
-			}
+			// IsBadWritePtr probes the range with SEH internally, so a faulting
+			// mapped physical address returns failure instead of raising an
+			// access violation that can crash the process during dispatch.
+			if (PInvoke.IsBadWritePtr((void*)(pLinAddr + (nint)extra), (nuint)buffer.Length))
+				return false;
+
+			Marshal.Copy(buffer, 0, pLinAddr + (nint)extra, buffer.Length);
 			return true;
 		}
 		catch

--- a/src/AutoOS.Core/NativeMethods.txt
+++ b/src/AutoOS.Core/NativeMethods.txt
@@ -48,6 +48,8 @@ GetSystemFirmwareTable
 GetTokenInformation
 GlobalMemoryStatusEx
 HANDLE
+IsBadReadPtr
+IsBadWritePtr
 HRESULT
 IAudioClient
 IAudioClient3


### PR DESCRIPTION
Fixes the app crash at startup on machines where the XHCI runtime registers read as invalid memory.

### What was happening
- GetIMODState reads the XHCI interrupt-moderation registers from physical memory via InpOut's MapPhysToLin.
- On this machine that range faults on access, raising an AccessViolationException inside Buffer.MemoryCopy (SpanHelpers.Memmove).
- Because the process is R2R-composite and trimmed, the secondary fault during exception dispatch crashed the process instead of being catchable -> the app never got past startup with the Exception Processing Message 0xc0000005 dialog.

### The fix
- ReadMemory/WriteMemory now probe the mapped range with IsBadReadPtr/IsBadWritePtr before copying (these are SEH-protected, so a faulting address returns failure instead of raising an AV).
- The copy itself uses Marshal.Copy instead of Buffer.MemoryCopy.
- The write path also page-aligns the mapping like the read path, and got the same probe (it previously had none).

### Verified
- The app now launches and stays running on the affected machine; the Devices page (XHCI/IMOD toggles) loads and toggling IMOD writes to the registers correctly.